### PR TITLE
Adjust to new ARK networking code since v311.74

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ services:
       MAX_PLAYERS: 15
       RCON_ENABLE: "True"
       RCON_PORT: 32330
-      GAME_PORT: 7778
+      GAME_PORT: 7777
       QUERY_PORT: 27015
-      RAW_SOCKETS: "False"
       SERVER_PASSWORD: ""
       ADMIN_PASSWORD: "keepmesecret"
       SPECTATOR_PASSWORD: "keepmesecret"
@@ -81,9 +80,8 @@ services:
       MAX_PLAYERS: 15
       RCON_ENABLE: "False"
       RCON_PORT: 32331
-      GAME_PORT: 7780
+      GAME_PORT: 7779
       QUERY_PORT: 27016
-      RAW_SOCKETS: "False"
       SERVER_PASSWORD: ""
       ADMIN_PASSWORD: "keepmesecret"
       SPECTATOR_PASSWORD: "keepmesecret"

--- a/arkmanager-user.cfg
+++ b/arkmanager-user.cfg
@@ -9,7 +9,6 @@ ark_RCONPort="${RCON_PORT:=32330}"                                  # RCON Port
 ark_SessionName="${SESSION_NAME:=ARK Docker}"                       # if your session name needs special characters please use the .ini instead
 ark_Port="${GAME_PORT:=7778}"                                       # ARK server port (default 7777)
 ark_QueryPort="${QUERY_PORT:=27015}"                                # ARK query port (default 27015)
-ark_bRawSockets="${RAW_SOCKETS:=false}"                             # Uncomment if you want to use ark raw socket (instead of steam p2p) [Not recommended]
 ark_ServerPassword="${SERVER_PASSWORD}"                             # ARK server password, empty: no password required to login
 ark_ServerAdminPassword="${ADMIN_PASSWORD}"                         # ARK server admin password, KEEP IT SAFE!
 ark_SpectatorPassword="${SPECTATOR_PASSWORD}"                       # ARK spectator password, KEEP IT SAFE!

--- a/arkmanager.cfg
+++ b/arkmanager.cfg
@@ -31,7 +31,8 @@ mod_branch="Windows"
 
 # Need to be true to work with UPDATEPONSTART (See #10)
 arkAutoUpdateOnStart="true"                                         # set this to true if you want to always update before startup
-arkBackupPreUpdate="false"                                           # set this to true if you want to perform a backup before updating
+arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
+arkNoPortDecrement="true"                                           # unset this to use the old Port - 1 behaviour
 
 defaultinstance="main"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,8 @@ services:
       MAX_PLAYERS: 15
       RCON_ENABLE: "True"
       RCON_PORT: 32330
-      GAME_PORT: 7778
+      GAME_PORT: 7777
       QUERY_PORT: 27015
-      RAW_SOCKETS: "False"
       SERVER_PASSWORD: ""
       ADMIN_PASSWORD: "keepmesecret"
       SPECTATOR_PASSWORD: "keepmesecret"
@@ -60,9 +59,8 @@ services:
       MAX_PLAYERS: 15
       RCON_ENABLE: "True"
       RCON_PORT: 32331
-      GAME_PORT: 7780
+      GAME_PORT: 7779
       QUERY_PORT: 27016
-      RAW_SOCKETS: "False"
       SERVER_PASSWORD: ""
       ADMIN_PASSWORD: "keepmesecret"
       SPECTATOR_PASSWORD: "keepmesecret"


### PR DESCRIPTION
Since v311.74 the ARK networking code changed so that ARK listens on different ports.

ark-server-tools have just been adjusted accordingly (https://github.com/FezVrasta/ark-server-tools/issues/1103)

We need a rebuild of arkcluster-base (for new arkmanager version) and arkcluster(to use the new default setting).