### PR TITLE
Fix BattlEye flag typo

### DIFF
--- a/arkmanager-user.cfg
+++ b/arkmanager-user.cfg
@@ -22,7 +22,7 @@ arkopt_clusterid="${CLUSTER_ID}"
 #arkflag_OnlyAdminRejoinAsSpectator=true                            # Uncomment to only allow admins to rejoin as spectator
 #arkflag_DisableDeathSpectator=true                                 # Uncomment to disable players from becoming spectators when they die
 arkflag_log=true
-arkflag_NoBattleEye=true
+arkflag_NoBattlEye=true
 arkflag_NoTransferFromFiltering=true
 arkopt_ShowFloatingDamageText=true
 


### PR DESCRIPTION
BattlEye was always enabled because it was misspelled in this file